### PR TITLE
docs: fixes package namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npx expo install @bounceapp/iframe react-native-webview
 ```tsx
 import React from "react"
 
-import { Iframe } from "@bounce/iframe"
+import { Iframe } from "@bounceapp/iframe"
 
 const App = () => (
   <Iframe uri="https://usebounce.com/careers" style={{ flex: 1 }} />

--- a/src/Iframe.tsx
+++ b/src/Iframe.tsx
@@ -6,7 +6,7 @@ import { IframeProps } from "./types"
  * ```tsx
  * import React from "react"
  *
- * import { Iframe } from "@bounce/iframe"
+ * import { Iframe } from "@bounceapp/iframe"
  *
  * const App = () => (
  *   <Iframe uri="https://usebounce.com/careers" style={{ flex: 1 }} />


### PR DESCRIPTION
The package namespace is wrong in the docs and code comments, this fixes #145 .
